### PR TITLE
feat: integrate ListProductModal into Marketplace page

### DIFF
--- a/src/app/(dashboard)/marketplace/page.tsx
+++ b/src/app/(dashboard)/marketplace/page.tsx
@@ -16,6 +16,7 @@ import { SearchProvider, useSearch } from "@/components/search/SearchContext"
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { Search } from "@/components/search/Search"
 import { useSearchCache } from "@/hooks/useSearchCache"
+import ListProductModal from "@/components/modal/ListProductModal"
 
 // Mock data for categories
 const categories = [
@@ -125,6 +126,7 @@ function MarketplaceContent() {
   const searchParams = useSearchParams()
   const { query, view, isLoading, setIsLoading, filters, priceRange: currentPriceRange } = useSearch()
   const [isFilterOpen, setIsFilterOpen] = useState(false)
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   // Use a ref to track the current tab value
   const activeTabRef = useRef(searchParams.get("type") || "all")
@@ -187,6 +189,20 @@ function MarketplaceContent() {
       lastUrlRef.current = newUrl
       router.push(newUrl, { scroll: false })
     }
+  }
+
+  // Handle form submission from the modal
+  const handleModalSubmit = (product: {
+    title: string;
+    category: string;
+    price: string;
+    description: string;
+    image: File | null;
+  }) => {
+    // Here you would typically send the data to an API
+    console.log('New Product:', product)
+    // Close the modal after submission
+    setIsModalOpen(false)
   }
 
   // Update activeTab when URL type parameter changes
@@ -253,14 +269,13 @@ function MarketplaceContent() {
             </SheetContent>
           </Sheet>
 
+          {/* Modified List Product Button */}
           <Button
+            onClick={() => setIsModalOpen(true)} // Open modal on click
             className="bg-gradient-to-r from-[#0075FF] to-[#00C2FF] text-white hover:from-[#0075FF]/90 hover:to-[#00C2FF]/90"
-            asChild
           >
-            <Link href="/marketplace/list-product">
-              <ListPlus className="mr-2 h-4 w-4" />
-              List Product
-            </Link>
+            <ListPlus className="mr-2 h-4 w-4" />
+            List Product
           </Button>
         </div>
       </div>
@@ -285,6 +300,13 @@ function MarketplaceContent() {
           <Pagination totalPages={5} />
         </div>
       )}
+
+      {/* Render the ListProductModal */}
+      <ListProductModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onSubmit={handleModalSubmit}
+      />
     </div>
   )
 }

--- a/src/components/modal/ListProductModal.tsx
+++ b/src/components/modal/ListProductModal.tsx
@@ -1,0 +1,166 @@
+// components/ListProductModal.tsx
+import React, { useState } from 'react';
+
+interface ListProductModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (product: { title: string; category: string; price: string; description: string; image: File | null }) => void;
+}
+
+const ListProductModal: React.FC<ListProductModalProps> = ({ isOpen, onClose, onSubmit }) => {
+  // Form state for new product
+  const [newProduct, setNewProduct] = useState({
+    title: '',
+    category: 'Physical',
+    price: '',
+    description: '',
+    image: null as File | null,
+  });
+
+  // Handle form input changes
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setNewProduct((prev) => ({ ...prev, [name]: value }));
+  };
+
+  // Handle image upload
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      setNewProduct((prev) => ({ ...prev, image: e.target.files![0] }));
+    }
+  };
+
+  // Handle form submission
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(newProduct);
+    // Reset form
+    setNewProduct({
+      title: '',
+      category: 'Physical',
+      price: '',
+      description: '',
+      image: null,
+    });
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-95 flex items-center justify-center z-50">
+      <div className="bg-dark-bg rounded-lg p-6 w-full max-w-lg border">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-2xl font-bold text-white">List a New Product</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-white transition">
+            ✕
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Product Title */}
+          <div>
+            <label htmlFor="title" className="block text-sm font-medium mb-1 text-white">
+              Product Title
+            </label>
+            <input
+              type="text"
+              id="title"
+              name="title"
+              value={newProduct.title}
+              onChange={handleInputChange}
+              className="w-full bg-gray-800 text-white rounded-lg py-2 px-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Enter product title"
+              required
+            />
+          </div>
+
+          {/* Category */}
+          <div>
+            <label htmlFor="category" className="block text-sm font-medium mb-1 text-white">
+              Category
+            </label>
+            <select
+              id="category"
+              name="category"
+              value={newProduct.category}
+              onChange={handleInputChange}
+              className="w-full bg-gray-800 text-white rounded-lg py-2 px-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="Physical">Physical</option>
+              <option value="Digital">Digital</option>
+            </select>
+          </div>
+
+          {/* Price */}
+          <div>
+            <label htmlFor="price" className="block text-sm font-medium mb-1 text-white">
+              Price (XLM)
+            </label>
+            <input
+              type="text"
+              id="price"
+              name="price"
+              value={newProduct.price}
+              onChange={handleInputChange}
+              className="w-full bg-gray-800 text-white rounded-lg py-2 px-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Enter price in XLM"
+              required
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label htmlFor="description" className="block text-sm font-medium mb-1 text-white">
+              Description
+            </label>
+            <textarea
+              id="description"
+              name="description"
+              value={newProduct.description}
+              onChange={handleInputChange}
+              className="w-full bg-gray-800 text-white rounded-lg py-2 px-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Enter product description"
+              rows={4}
+              required
+            />
+          </div>
+
+          {/* Image Upload */}
+          <div>
+            <label htmlFor="image" className="block text-sm font-medium mb-1 text-white">
+              Product Image
+            </label>
+            <input
+              type="file"
+              id="image"
+              name="image"
+              accept="image/*"
+              onChange={handleImageChange}
+              className="w-full bg-gray-800 text-white rounded-lg py-2 px-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {/* Submit Button */}
+          <div className="flex justify-end gap-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="bg-gray-600 text-white px-4 py-2 rounded-lg hover:bg-gray-700 transition"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
+            >
+              List Product
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ListProductModal;


### PR DESCRIPTION
# Integrate List Product Modal into Marketplace Page

## Description

This pull request integrates the `ListProductModal` component into the Marketplace page. The "List Product" button now opens a modal instead of navigating to a new page, providing a seamless user experience for listing new products.

### Changes Made
- Updated the "List Product" button in `app/marketplace/page.tsx`:
  - Removed the `Link` component and `asChild` prop.
  - Added an `onClick` handler to set `isModalOpen` to `true`.
- Added the `ListProductModal` component at the root level of `MarketplaceContent`.
- Ensured the modal integrates with existing state (`isModalOpen` and `handleModalSubmit`).
- Verified that the modal's styling (dark theme, blue accents) aligns with the Marketplace design.

## Screenshots
![Screenshot from 2025-04-29 18-42-24](https://github.com/user-attachments/assets/da442bfb-a7ca-4e95-9311-c0d29985d085)


## Related Issues
- Closes #4

## Checklist
- [x] Code follows project style guidelines.
- [x] The modal is responsive across different screen sizes.
- [x] The modal works as expected with no regressions.
- [x] No linting or build errors (`npm run lint` and `npm run build` pass).
